### PR TITLE
Adjust the number of maxParallelForks when running tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ application {
 
 tasks.withType<Test> {
     useJUnitPlatform {
-        maxParallelForks = Runtime.getRuntime().availableProcessors()
+        maxParallelForks = Math.max(1, Runtime.getRuntime().availableProcessors() - 2)
         if (project.hasProperty("skipUI")) {
             excludeTags("UI")
         }


### PR DESCRIPTION
Essentially my window environment occasionally locks up and becomes unresponsive when running 12 processes at 100%. This reduces the number of processes for running tests by two, with a total min. of 1 (for travis). This change has been working for me, but I've gotten tired of editing `build.gradle.kts` and remembering to not stage it, so I'd like to merge it into master.

Issue number(s) that has/have been address in this branch: None

My pull request is ready to be reviewed: **yes**
